### PR TITLE
Fix a deprecation warning in SimpleEval._eval_num()

### DIFF
--- a/rolldice/rolldice.py
+++ b/rolldice/rolldice.py
@@ -180,9 +180,9 @@ class SimpleEval(object):
         :return: Result of node
         """
         if self.floats:
-            return node.n
+            return node.value
         else:
-            return int(node.n)
+            return int(node.value)
 
     def _eval_unaryop(self, node):
         """


### PR DESCRIPTION
I have stumbled in the following deprecation warning when executing the code:

```
rolldice/rolldice.py:175: DeprecationWarning: Attribute n is deprecated and will be removed in Python 3.14; use value instead
    return node.n
```

The Fix just rename `node.n` to `node.value`.